### PR TITLE
Patched the excelize library to output cell style information along with column values in stream reader

### DIFF
--- a/cell.go
+++ b/cell.go
@@ -9,6 +9,9 @@
 // API for generating or reading data from a worksheet with huge amounts of
 // data. This library needs Go version 1.18 or later.
 
+// Package excelize - Forked from v2.9.0 of excelize library - https://github.com/qax-os/excelize
+// Look for <PATCHED LINE> to see the changes made to the original code.
+
 package excelize
 
 import (
@@ -643,6 +646,15 @@ func (c *xlsxC) getValueFrom(f *File, d *xlsxSST, raw bool) (string, error) {
 		}
 		return f.formattedValue(c, raw, CellTypeNumber)
 	}
+}
+
+// <PATCHED LINE>
+// getValueAndStyleFrom return a value and styleID from a column/row cell, this function is
+// intended to be used with for range on rows an argument with the spreadsheet
+// opened file.
+func (c *xlsxC) getValueAndStyleFrom(f *File, d *xlsxSST, raw bool) (string, int, error) {
+	value, err := c.getValueFrom(f, d, raw)
+	return value, c.S, err
 }
 
 // SetCellDefault provides a function to set string type value of a cell as

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/xuri/excelize/v2
+module github.com/SimpleDataLabsInc/excelize/v2
 
 go 1.18
 

--- a/rows.go
+++ b/rows.go
@@ -9,6 +9,9 @@
 // API for generating or reading data from a worksheet with huge amounts of
 // data. This library needs Go version 1.18 or later.
 
+// Package excelize - Forked from v2.9.0 of excelize library - https://github.com/qax-os/excelize
+// Look for <PATCHED LINE> to see the changes made to the original code.
+
 package excelize
 
 import (
@@ -195,6 +198,60 @@ func (rows *Rows) Columns(opts ...Options) ([]string, error) {
 	return rowIterator.cells, rowIterator.err
 }
 
+// <PATCHED LINE> start
+
+// ColumnsWithCorrespondingStyleIDs return the current row's column values along with their style IDs. This fetches the worksheet
+// data as a stream, returns each cell in a row as is, and will not skip empty
+// rows in the tail of the worksheet.
+func (rows *Rows) ColumnsWithCorrespondingStyleIDs(opts ...Options) ([]string, []int, error) {
+	if rows.curRow > rows.seekRow {
+		return nil, nil, nil
+	}
+	var rowIterator rowXMLIteratorV2
+	var token xml.Token
+	rows.rawCellValue = rows.f.getOptions(opts...).RawCellValue
+	if rows.sst, rowIterator.err = rows.f.sharedStringsReader(); rowIterator.err != nil {
+		return rowIterator.cells, rowIterator.styleIDs, rowIterator.err
+	}
+	for {
+		if rows.token != nil {
+			token = rows.token
+		} else if token, _ = rows.decoder.Token(); token == nil {
+			break
+		}
+		switch xmlElement := token.(type) {
+		case xml.StartElement:
+			rowIterator.inElement = xmlElement.Name.Local
+			if rowIterator.inElement == "row" {
+				rowNum := 0
+				if rowNum, rowIterator.err = attrValToInt("r", xmlElement.Attr); rowNum != 0 {
+					rows.curRow = rowNum
+				} else if rows.token == nil {
+					rows.curRow++
+				}
+				rows.token = token
+				rows.seekRowOpts = extractRowOpts(xmlElement.Attr)
+				if rows.curRow > rows.seekRow {
+					rows.token = nil
+					return rowIterator.cells, rowIterator.styleIDs, rowIterator.err
+				}
+			}
+			if rows.rowXMLHandlerV2(&rowIterator, &xmlElement, rows.rawCellValue); rowIterator.err != nil {
+				rows.token = nil
+				return rowIterator.cells, rowIterator.styleIDs, rowIterator.err
+			}
+			rows.token = nil
+		case xml.EndElement:
+			if xmlElement.Name.Local == "sheetData" {
+				return rowIterator.cells, rowIterator.styleIDs, rowIterator.err
+			}
+		}
+	}
+	return rowIterator.cells, rowIterator.styleIDs, rowIterator.err
+}
+
+// <PATCHED LINE> end
+
 // extractRowOpts extract row element attributes.
 func extractRowOpts(attrs []xml.Attr) RowOpts {
 	rowOpts := RowOpts{Height: defaultRowHeight}
@@ -217,6 +274,17 @@ func appendSpace(l int, s []string) []string {
 	}
 	return s
 }
+
+// <PATCHED LINE> start
+// appendSpaceInt append blank integers to slice by given length and source slice.
+func appendSpaceInt(l int, s []int) []int {
+	for i := 1; i < l; i++ {
+		s = append(s, 0)
+	}
+	return s
+}
+
+// <PATCHED LINE> end
 
 // rowXMLIterator defined runtime use field for the worksheet row SAX parser.
 type rowXMLIterator struct {
@@ -243,6 +311,37 @@ func (rows *Rows) rowXMLHandler(rowIterator *rowXMLIterator, xmlElement *xml.Sta
 		}
 	}
 }
+
+// <PATCHED LINE> start
+// rowXMLIteratorV2 defined runtime use field for the worksheet row SAX parser.
+type rowXMLIteratorV2 struct {
+	err              error
+	inElement        string
+	cellCol, cellRow int
+	cells            []string
+	styleIDs         []int
+}
+
+// rowXMLHandlerV2 parse the row XML element of the worksheet.
+func (rows *Rows) rowXMLHandlerV2(rowIterator *rowXMLIteratorV2, xmlElement *xml.StartElement, raw bool) {
+	if rowIterator.inElement == "c" {
+		rowIterator.cellCol++
+		colCell := xlsxC{}
+		_ = rows.decoder.DecodeElement(&colCell, xmlElement)
+		if colCell.R != "" {
+			if rowIterator.cellCol, _, rowIterator.err = CellNameToCoordinates(colCell.R); rowIterator.err != nil {
+				return
+			}
+		}
+		blank := rowIterator.cellCol - len(rowIterator.cells)
+		if val, styleID, _ := colCell.getValueAndStyleFrom(rows.f, rows.sst, raw); val != "" || colCell.F != nil {
+			rowIterator.cells = append(appendSpace(blank, rowIterator.cells), val)
+			rowIterator.styleIDs = append(appendSpaceInt(blank, rowIterator.styleIDs), styleID)
+		}
+	}
+}
+
+// <PATCHED LINE> end
 
 // Rows returns a rows iterator, used for streaming reading data for a
 // worksheet with a large data. This function is concurrency safe. For


### PR DESCRIPTION
# PR Details

We were seeing a really big memory overhead when trying to get cell style for each cell separately. This patch adds new public API to the library which lets us get Column values and their corresponding styleIDs per row.

## Description

Made use of the `getValueFrom` method which has access to `styleID` of the cell by creating new method which returns cell's StyleID along with value of the cell. Created new `ColumnsWithCorrespondingStyleIDs` API which uses the updated `getValueAndStyleFrom` method.

Asana Ticket: https://app.asana.com/1/711615303573503/project/1201259583869898/task/1210648045285184?focus=true